### PR TITLE
fix: fix production build and mobile hamburger menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
+      ">1%",
       "not dead",
       "not op_mini all"
     ],

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -45,6 +45,7 @@ function Component()
 				<li><A href="/bootstrap" className={(currentPath==='/bootstrap')?'active':''} title="Bootstrap a Testnet Node" onClick={toggleMenu}>Bootstrap</A></li>
 				<li><A href="/generator" className={(currentPath==='/generator')?'active':''} title="Generator Tool">Generator</A></li>
 				<li><A href="/sudt" className={(currentPath==='/sudt')?'active':''} title="SUDT Tool" onClick={toggleMenu}>SUDT</A></li>
+				<li><A href="/create-layer2-account" className={(currentPath==='/create-layer2-account')?'active':''} title="Create Layer 2 Account">Create Layer 2 Account</A></li>
 				<li><A href="/about" className={(currentPath==='/about')?'active':''} title="About" onClick={toggleMenu}>About</A></li>
 				<li><A href="/contact" className={(currentPath==='/contact')?'active':''} title="Contact" onClick={toggleMenu}>Contact</A></li>
 				<li><a href="https://github.com/jordanmack/ckb-tools" target="_blank" rel="noreferrer" title="GitHub" onClick={toggleMenu}>GitHub</a></li>


### PR DESCRIPTION
1. Fix production build Babel error by bumping supported browsers from `> 0.2%` to `> 1%`.
2. Add Create Layer 2 Account tab to hamburger menu on mobile view.

Travis build is failing probably because of cached node_modules. Deleting Travis cache and restarting the build should fix it. I can't do it because I'm not admin.