### PR TITLE
fix: disable withdrawal and mainnet until implemented

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,7 @@ const config =
 				hash_type: 'type'
 			},
 			withdrawalLockCellDep: {
-				tx_hash: '0xb4b07dcd1571ac18683b515ada40e13b99bd0622197b6817047adc9f407f4828',
+				tx_hash: '0x226311b5038e963296d94d31823c16bb572d9b5daa459d37d49834c67fcbe090',
 				index: '0x0',
 				depType: 'code'
 			}

--- a/src/containers/CreateLayerTwoAccount/CreateLayerTwoAccount.tsx
+++ b/src/containers/CreateLayerTwoAccount/CreateLayerTwoAccount.tsx
@@ -149,12 +149,12 @@ const fetchConnectedAccountBalance = useCallback(async function () {
 return <main className="create-l2-account">
 		{loading && <LoadingSpinner />}
 		<section className="chain-type">
-						<label title='Chain types can be either Mainnet or Testnet.'>
+						<label title='Mainnet is unavailable until new version (v1) comes out.'>
 							Nervos CKB Chain Type
 							<SegmentedControl name="chain-type" setValue={handleChainChanged} options={
 								[
-									{label: 'Testnet', value: ChainTypes.testnet, default: true},
-									{label: 'Mainnet', value: ChainTypes.mainnet},
+									{label: 'Testnet (v1, Omnilock)', value: ChainTypes.testnet, default: true},
+									{label: 'Mainnet', value: ChainTypes.mainnet, disabled: true},
 								]
 							} />
 						</label>
@@ -240,7 +240,7 @@ return <main className="create-l2-account">
 			Please connect Ethereum account. Check for "Connect account" modal in your wallet extension.	
 		</div>}
 		
-	{Boolean(layer2Balance) && <><br/><br/><br/><hr /><br/><br/><button onClick={() => setWithdrawVisibility(!withdrawVisibile)}>Toggle Withdraw view</button></>}
+	{Boolean(layer2Balance) && <><br/><br/><br/><hr /><br/><br/><button title="Withdrawal using ckb.tools UI is not implemented yet for new version of network (v1)." disabled={true} onClick={() => setWithdrawVisibility(!withdrawVisibile)}>Toggle Withdraw view</button></>}
 	{withdrawVisibile && addressTranslator && connectedEthAddress && <><br/><br/><br/><WithdrawLayerTwo addressTranslator={addressTranslator} chainType={chainType} ethAddress={connectedEthAddress} /></>}
 	</main>
 }


### PR DESCRIPTION
Mainnet v1 is unreleased yet and withdrawal logic has changed substantially and will be implemented in a separate PR. Withdrawing from Godwoken now uses Typed Signing.